### PR TITLE
Create initial documentation for POML Go port

### DIFF
--- a/_docs/agents.md
+++ b/_docs/agents.md
@@ -1,0 +1,27 @@
+# POML Go Porting Project
+
+This document outlines the goals and structure of the Go port for the POML template engine.
+
+## Goals
+
+The primary goal of this project is to create a Go implementation of the POML template engine that is compatible with the existing Python and JS/TS implementations.
+
+The Go port should:
+- Parse and render `.poml` files.
+- Support the full POML language specification, including the template engine features.
+- Provide a simple and intuitive API for developers.
+- Be well-documented and easy to use.
+
+## Project Structure
+
+The project will be structured as follows:
+
+- `_docs`: Contains the documentation for the project, including this file.
+- `src`: Will contain the Go source code for the POML engine.
+- `examples`: Will contain example `.poml` files and Go programs demonstrating how to use the engine.
+- `tests`: Will contain the test suite for the Go implementation.
+
+## References
+
+- **Official POML Documentation:** [https://microsoft.github.io/poml/latest/](https://microsoft.github.io/poml/latest/)
+- **Official POML Repository:** [https://github.com/microsoft/poml](https://github.com/microsoft/poml)

--- a/_docs/js-ts-api.md
+++ b/_docs/js-ts-api.md
@@ -1,0 +1,48 @@
+# POML JS/TS API
+
+This document describes the JS/TS API for the POML template engine, based on the official documentation.
+
+The JS/TS SDK allows you to work with POML using a JSX-like syntax in your TypeScript or JavaScript code.
+
+## Installation
+
+```bash
+npm install pomljs
+```
+
+## Core Functions
+
+The JS/TS API is centered around two core functions: `read` and `write`.
+
+- **`read(prompt)`:** Parses the prompt components (written in JSX-like syntax) into an intermediate representation (IR).
+- **`write(ir)`:** Renders the IR into different formats (e.g., markdown).
+
+## Quick Start
+
+Here is a quick example of how to use the JS/TS API:
+
+```typescript
+import { Paragraph, Image } from 'poml/essentials';
+import { read, write } from 'poml';
+
+const prompt = <Paragraph>
+  Hello, world! Here is an image:
+  <Image src="photo.jpg" alt="A beautiful scenery" />
+</Paragraph>;
+
+// Parse the prompt components into an intermediate representation (IR)
+const ir = await read(prompt);
+
+// Render it to markdown
+const markdown = write(ir);
+```
+
+## Modules
+
+The JS/TS SDK is organized into several modules:
+
+- **`essentials`:** Provides the basic POML components like `<Paragraph>` and `<Image>`.
+- **`base`:** Contains the base components and utilities.
+- **`cli`:** The command-line interface.
+- **`file`:** Utilities for working with files.
+- **`writer`:** The rendering engine that writes the IR to different formats.

--- a/_docs/language-spec.md
+++ b/_docs/language-spec.md
@@ -1,0 +1,115 @@
+# POML Language Specification
+
+This document describes the specification of the POML language, based on the official documentation.
+
+## Basic Syntax
+
+POML uses an XML-like syntax with tags, attributes, and content.
+
+- **Tags:** Mark the beginning and end of an element (e.g., `<p>`, `</p>`).
+- **Attributes:** Provide additional information about an element (e.g., `<p speaker="human">`).
+- **Content:** The text or other elements between the opening and closing tags.
+
+The root of a POML document should be a `<poml>` tag.
+
+## Template Engine
+
+POML includes a powerful template engine with the following features:
+
+### Expressions
+
+Expressions are enclosed in double curly brackets (`{{ }}`) and can be used to evaluate variables and JavaScript expressions.
+
+```poml
+<poml>
+  <p>Hello, {{name}}!</p>
+</poml>
+```
+
+### Let Expressions
+
+The `<let>` tag is used to define variables and import data.
+
+- **Set a variable from a value:**
+  ```poml
+  <let name="greeting" value="Hello, world!" />
+  ```
+- **Import data from a file:**
+  ```poml
+  <let name="users" src="users.json" />
+  ```
+- **Set a variable from inline JSON:**
+  ```poml
+  <let name="person">
+    {
+      "name": "Alice",
+      "age": 30
+    }
+  </let>
+  ```
+
+### For Attribute
+
+The `for` attribute is used to loop over a list.
+
+```poml
+<poml>
+  <list>
+    <item for="item in ['apple', 'banana', 'cherry']">{{item}}</item>
+  </list>
+</poml>
+```
+
+Loop variables (`loop.index`, `loop.length`, `loop.first`, `loop.last`) are available inside the loop.
+
+### If Condition
+
+The `if` attribute is used for conditional rendering.
+
+```poml
+<poml>
+  <p if="isVisible">This paragraph is visible.</p>
+</poml>
+```
+
+### Include Files
+
+The `<include>` tag is used to include content from another file.
+
+```poml
+<poml>
+  <include src="snippet.poml" />
+</poml>
+```
+
+## Stylesheet
+
+The `<stylesheet>` tag allows you to apply CSS-like styles (attributes) to elements.
+
+```poml
+<poml>
+  <stylesheet>
+    {
+      "p": {
+        "syntax": "json"
+      }
+    }
+  </stylesheet>
+  <p>This text will be rendered as JSON.</p>
+</poml>
+```
+
+Elements can be targeted by tag name or by `className` (e.g., `.csv`).
+
+## Escape Characters
+
+POML uses the following escape characters:
+
+- `#quot;` for `"`
+- `#apos;` for `'`
+- `#amp;` for `&`
+- `#lt;` for `<`
+- `#gt;` for `>`
+- `#hash;` for `#`
+- `#lbrace;` for `{`
+- `#rbrace;` for `}`

--- a/_docs/python-api.md
+++ b/_docs/python-api.md
@@ -1,0 +1,57 @@
+# POML Python API
+
+This document describes the Python API for the POML template engine, based on the official Python SDK.
+
+## `poml()` function
+
+The `poml()` function is the main entry point for the Python API. It processes POML markup and returns the result in the specified format.
+
+```python
+poml(
+    markup: str | Path,
+    context: dict | str | Path | None = None,
+    stylesheet: dict | str | Path | None = None,
+    chat: bool = True,
+    output_file: str | Path | None = None,
+    format: OutputFormat = "dict",
+    extra_args: Optional[List[str]] = None,
+) -> list | dict | str:
+```
+
+### Parameters
+
+- `markup`: The POML markup to process, as a string or a file path.
+- `context`: The context data to inject into the template.
+- `stylesheet`: The stylesheet to use for rendering.
+- `chat`: Whether to process as a chat conversation.
+- `output_file`: The path to save the output to.
+- `format`: The output format (`raw`, `dict`, `openai_chat`, `langchain`, `pydantic`).
+- `extra_args`: Additional command-line arguments to pass to the POML processor.
+
+## `Prompt` class
+
+The `Prompt` class provides a Pythonic way to build POML markup programmatically using context managers.
+
+```python
+from poml import Prompt
+
+with Prompt() as p:
+    with p.paragraph():
+        with p.task(id="task1", status="open"):
+            p.text("This is a task description.")
+        with p.paragraph():
+            p.text("This is a paragraph in the document.")
+
+# Get the rendered output
+prompt_output = p.render()
+
+# Get the generated XML for debugging
+xml_output = p.dump_xml()
+```
+
+### Methods
+
+- `render()`: Renders the final XML and returns the output.
+- `dump_xml()`: Returns the generated XML string.
+- `text()`: Adds text content to the currently open element.
+- `tag()`: Creates a new tag. You can also use methods like `p.paragraph()` as a shortcut.


### PR DESCRIPTION
This commit adds the initial documentation for a planned Go port of the POML template engine.

The documentation is located in the `_docs` directory and includes:
- `agents.md`: An overview of the project goals and structure.
- `language-spec.md`: A summary of the POML language specification.
- `python-api.md`: A description of the existing Python API.
- `js-ts-api.md`: A description of the existing JS/TS API.

This documentation was created by exploring the official POML repository and documentation.